### PR TITLE
Convert m/s to knots when plotting wind barbs

### DIFF
--- a/dlotter/plot.py
+++ b/dlotter/plot.py
@@ -385,7 +385,7 @@ class plot:
 
 
             axes.barbs(clons[::bt,::bt], clats[::bt,::bt],
-                       u[::bt,::bt], v[::bt,::bt],
+                       u[::bt,::bt]*1.94384, v[::bt,::bt]*1.94384,
                        length=5,
                        sizes=barbs_opts,
                        linewidth=0.95,


### PR DESCRIPTION
This is small hotfix to plot wind barbs in knots instead of m/s.
Ideally we should check the units in the input and move that along throughout the code.
Created an issue (https://github.com/dmidk/dlotter/issues/26) to remember this for later.